### PR TITLE
Added IM and EC3 services

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -24,8 +24,8 @@ sites:
     url: https://jenkins.eosc-synergy.eu/
     icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvpNArYk3fL0rZo9sh2nD7P2EHj-ul01oCOA&usqp=CAU
   - name: EC3
-    url: http://servproject.i3m.upv.es/ec3-synergy/
-    icon: http://servproject.i3m.upv.es/ec3/img/ec3-small.png
+    url: https://servproject.i3m.upv.es/ec3-synergy/
+    icon: https://servproject.i3m.upv.es/ec3/img/ec3-small.png
   - name: IM
     url: https://appsgrycap.i3m.upv.es:31443/im-dashboard/login
     icon: https://appsgrycap.i3m.upv.es:31443/im-dashboard/static/images/favicon_io/favicon-32x32.png

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,10 +23,12 @@ sites:
   - name: Jenkins
     url: https://jenkins.eosc-synergy.eu/
     icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvpNArYk3fL0rZo9sh2nD7P2EHj-ul01oCOA&usqp=CAU
-  - name: EC3
+  - name: EC3 portal for EOSC-Synergy
     url: https://servproject.i3m.upv.es/ec3-synergy/
     icon: https://servproject.i3m.upv.es/ec3/img/ec3-small.png
-  - name: IM
+    expectedStatusCodes:
+      - 403
+  - name: IM - Infrastructure Manager
     url: https://appsgrycap.i3m.upv.es:31443/im-dashboard/login
     icon: https://appsgrycap.i3m.upv.es:31443/im-dashboard/static/images/favicon_io/favicon-32x32.png
   

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,6 +23,12 @@ sites:
   - name: Jenkins
     url: https://jenkins.eosc-synergy.eu/
     icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvpNArYk3fL0rZo9sh2nD7P2EHj-ul01oCOA&usqp=CAU
+  - name: EC3
+    url: http://servproject.i3m.upv.es/ec3-synergy/
+    icon: http://servproject.i3m.upv.es/ec3/img/ec3-small.png
+  - name: IM
+    url: https://appsgrycap.i3m.upv.es:31443/im-dashboard/login
+    icon: https://appsgrycap.i3m.upv.es:31443/im-dashboard/static/images/favicon_io/favicon-32x32.png
   
 status-website:
   # Add your custom domain below, or remove the next line if you don't have a domain


### PR DESCRIPTION
Hi,

I've added IM and EC3 services to control the status of them. I have a doubt regarding EC3 portal, as you need to login with EGI Checkin before accessing the portal. If this is not possible, we can reference to the public endpoint of EC3 that does not need authentication (https://servproject.i3m.upv.es/ec3/).

Thank you!