### PR TITLE
Delete expectedStatusCodes from EC3

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -26,8 +26,6 @@ sites:
   - name: EC3 portal for EOSC-Synergy
     url: https://servproject.i3m.upv.es/ec3-synergy/
     icon: https://servproject.i3m.upv.es/ec3/img/ec3-small.png
-    expectedStatusCodes:
-      - 403
   - name: IM - Infrastructure Manager
     url: https://appsgrycap.i3m.upv.es:31443/im-dashboard/login
     icon: https://appsgrycap.i3m.upv.es:31443/im-dashboard/static/images/favicon_io/favicon-32x32.png


### PR DESCRIPTION
EC3 web is returning 200 code, so the parameter 'expectedStatusCodes' is not needed. Sorry for the inconvenience.